### PR TITLE
cut out row and column labels

### DIFF
--- a/orm.go
+++ b/orm.go
@@ -303,11 +303,6 @@ func (idx *Index) Name() string {
 	return idx.name
 }
 
-// ColumnLabel returns the column label for this index.
-func (idx *Index) ColumnLabel() string {
-	return idx.options.ColumnLabel
-}
-
 // Frame creates a frame struct with the specified name and defaults.
 func (idx *Index) Frame(name string, options ...interface{}) (*Frame, error) {
 	if frame, ok := idx.frames[name]; ok {
@@ -576,11 +571,6 @@ func newFrame(name string, index *Index) *Frame {
 // Name returns the name of the frame
 func (f *Frame) Name() string {
 	return f.name
-}
-
-// RowLabel returns the row label for this frame.
-func (f *Frame) RowLabel() string {
-	return f.options.RowLabel
 }
 
 func (f *Frame) copy() *Frame {

--- a/response_test.go
+++ b/response_test.go
@@ -33,6 +33,7 @@
 package pilosa
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -173,9 +174,22 @@ func TestNewQueryResponseFromInternalFailure(t *testing.T) {
 }
 
 func TestCountResultItemToString(t *testing.T) {
-	item := &CountResultItem{ID: 100, Count: 50}
-	target := "100:50"
-	if target != item.String() {
-		t.Fatalf("%s != %s", target, item.String())
+	tests := []struct {
+		item     *CountResultItem
+		expected string
+	}{
+		{item: &CountResultItem{ID: 100, Count: 50}, expected: "100:50"},
+		{item: &CountResultItem{Key: "blah", Count: 50}, expected: "blah:50"},
+		{item: &CountResultItem{Key: "blah", ID: 22, Count: 50}, expected: "blah:50"},
+		{item: &CountResultItem{Key: "blah", ID: 22}, expected: "blah:0"},
+		{item: &CountResultItem{}, expected: "0:0"},
+	}
+
+	for i, tst := range tests {
+		t.Run(fmt.Sprintf("%d: ", i), func(t *testing.T) {
+			if tst.expected != tst.item.String() {
+				t.Fatalf("%s != %s", tst.expected, tst.item.String())
+			}
+		})
 	}
 }


### PR DESCRIPTION
I created a new PR in the enterprise repo which removes support for row and column labels.